### PR TITLE
Removed a trailing whitespace

### DIFF
--- a/lib/Dist/Zilla/Plugin/MakeMaker/Awesome.pm
+++ b/lib/Dist/Zilla/Plugin/MakeMaker/Awesome.pm
@@ -37,7 +37,7 @@ my {{ $WriteMakefileArgs }}
 
 unless ( eval { ExtUtils::MakeMaker->VERSION(6.56) } ) {
   my $br = delete $WriteMakefileArgs{BUILD_REQUIRES};
-  my $pp = $WriteMakefileArgs{PREREQ_PM}; 
+  my $pp = $WriteMakefileArgs{PREREQ_PM};
   for my $mod ( keys %$br ) {
     if ( exists $pp->{$mod} ) {
       $pp->{$mod} = $br->{$mod} if $br->{$mod} > $pp->{$mod}; 


### PR DESCRIPTION
The trailing whitespace causes EOLTests to fail.
