### PR TITLE
add missing load of Data::Dumper

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,8 @@ Revision history for Dist::Zilla::Plugin::MakeMaker::Awesome
 
 {{$NEXT}}
 
+    - fix load issue with Data::Dumper (Karen Etheridge)
+
 0.12 2011-01-29 11:58:27
 
     - Remove a trailing space in Awesome.pm, patch by Jesse Luehrs at

--- a/lib/Dist/Zilla/Plugin/MakeMaker/Awesome.pm
+++ b/lib/Dist/Zilla/Plugin/MakeMaker/Awesome.pm
@@ -7,6 +7,7 @@ use List::MoreUtils qw(any uniq);
 use Dist::Zilla::File::InMemory;
 use namespace::autoclean;
 use Dist::Zilla::Plugin::MakeMaker 4.101830;
+use Data::Dumper;
 
 extends 'Dist::Zilla::Plugin::MakeMaker';
 


### PR DESCRIPTION
I'm not sure exactly how this is an issue when it has never been before, but I encountered

```
Can't locate object method "new" via package "Data::Dumper" at /Users/ether/.perlbrew/libs/16.3@std/lib/perl5/Dist/Zilla/Plugin/MakeMaker/Awesome.pm line 134.
```

...while attempting to build Moose using Test::Builder 1.5 alpha.
