### PR TITLE
Add ability to insert custom code to Makefile.PL

### DIFF
--- a/t/makemaker.t
+++ b/t/makemaker.t
@@ -69,6 +69,35 @@ use Path::Tiny;
 
 {
   my $tzil = Builder->from_config(
+    { dist_root => 'does_not_exist' },
+    {
+      add_files => {
+        path(qw(source dist.ini)) => simple_ini(
+          'GatherDir',
+          [ 'MakeMaker::Awesome' => { makefile_args_hook => "\$WriteMakefileArgs{LIBS} = ['-lsome'];\n" } ],
+          [ Prereqs => { 'Foo::Bar' => '1.20',      perl => '5.008' } ],
+          [ Prereqs => BuildRequires => { 'Builder::Bob' => '9.901' } ],
+          [ Prereqs => TestRequires  => { 'Test::Deet'   => '7',
+                                          perl           => '5.008' } ],
+        ),
+        path(qw(source lib DZT Sample.pm)) => 'package DZT::Sample; 1',
+        path(qw(source t basic.t)) => 'warn "here is a test";',
+      },
+    },
+  );
+
+  $tzil->build;
+
+  my $content = $tzil->slurp_file('build/Makefile.PL');
+  like(
+    $content,
+    qr/^my\s+\%WriteMakefileArgs\s*=\s*\(.+^\$WriteMakefileArgs\{LIBS\} = \['-lsome'\];.+^WriteMakefile\(/ms,
+    'our hook exists in its place Makefile.PL',
+  );
+}
+
+{
+  my $tzil = Builder->from_config(
     { dist_root => 'corpus/dist/DZT' },
     {
       add_files => {


### PR DESCRIPTION
Add ability to insert custom code to Makefile.PL to add to %WriteMakefileArgs hash.

I need this to not override whole template. Why and sample to use documented in module’s pod.
