### PR TITLE
use VERSION method to check EUMM version

### DIFF
--- a/lib/Dist/Zilla/Plugin/MakeMaker/Awesome.pm
+++ b/lib/Dist/Zilla/Plugin/MakeMaker/Awesome.pm
@@ -54,7 +54,8 @@ use strict;
 use warnings;
 
 {{ $perl_prereq ? qq[use $perl_prereq;] : ''; }}
-use ExtUtils::MakeMaker{{ 0+$eumm_version ? ' ' . $eumm_version : '' }};
+use ExtUtils::MakeMaker;
+{{ 0+$eumm_version ? "BEGIN { ExtUtils::MakeMaker->VERSION('$eumm_version') }" : '' }}
 
 {{ $header }}
 

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -78,7 +78,8 @@ use strict;
 use warnings;
 
 use 5\.008;
-use ExtUtils::MakeMaker 6\.00;
+use ExtUtils::MakeMaker;
+BEGIN \{ ExtUtils::MakeMaker->VERSION\('6\.00'\) }
 
 my \%WriteMakefileArgs = \(/,
     'Makefile.PL header looks correct',

--- a/t/05-simple-configs.t
+++ b/t/05-simple-configs.t
@@ -30,7 +30,7 @@ my $tzil = Builder->from_config(
             ) . <<END_INI,
 
 [MakeMaker::Awesome]
-eumm_version = 6.00
+eumm_version = 6.00_00
 WriteMakefile_arg = CCFLAGS => '-Wall'
 test_file = xt/*.t
 exe_file = bin/hello-world
@@ -59,7 +59,8 @@ is(
 use strict;
 use warnings;
 
-use ExtUtils::MakeMaker 6.00;
+use ExtUtils::MakeMaker;
+BEGIN { ExtUtils::MakeMaker->VERSION('6.00_00') }
 
 my \$string = 'oh hai';
 


### PR DESCRIPTION
The `use ExtUtils::MakeMaker VERSION` syntax unfortunately requires a bareword which means that it will not compare underscore versions correctly without a recent version of version.pm loaded.

```
> perl -e'use ExtUtils::MakeMaker 6.55_02; print "1\n"' 
ExtUtils::MakeMaker version 6.5502 required--this is only version 6.55_02 at -e line 1.
```

Using the ->VERSION method we can make sure the requested version is passed as a string preserving underscores, which is necessary for older EUMM that did not remove the underscore at runtime.

```
> perl -e'use ExtUtils::MakeMaker; BEGIN { ExtUtils::MakeMaker->VERSION("6.55_02") } print "1\n"'
1
```

This could be helpful for those using features from EUMM that are noted to require a particular underscore version, usually because that version was in core.