### PR TITLE
Fix #10 - Copy hidden files and dirs from share dirs

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for Dist-Zilla-Plugin-MakeMaker-Awesome
 
 {{$NEXT}}
+  - ensure DOTFILES and DOTDIRS are copied over from shared dirs during
+    install, matching the behaviour of <Dist::Zilla::Plugin::MakeMaker>.
 
 0.47      2018-07-11 03:33:49Z
   - fix test failures in various plugins caused by innocent changes in 0.46

--- a/lib/Dist/Zilla/Plugin/MakeMaker/Awesome.pm
+++ b/lib/Dist/Zilla/Plugin/MakeMaker/Awesome.pm
@@ -320,6 +320,8 @@ sub _build_share_dir_block {
     if ( keys %$share_dir_map ) {
         # split in two to foil CPANTS prereq_matches_use
         my $preamble = qq{use File::Shar}.qq{eDir::Install;\n};
+        $preamble .= qq{\$File::ShareDir::Install::INCLUDE_DOTFILES = 1;\n};
+        $preamble .= qq{\$File::ShareDir::Install::INCLUDE_DOTDIRS = 1;\n};
         if ( my $dist_share_dir = $share_dir_map->{dist} ) {
             $dist_share_dir = quotemeta $dist_share_dir;
             $preamble .= qq{install_share dist => "$dist_share_dir";\n};


### PR DESCRIPTION
Hi,

This change fixes #10, ensuring that **hidden files and directories** are indeed copied over from shared dirs during install.

It does this by mimicking the current (imho, _correct_) behaviour of [Dist::Zilla::Plugin::MakeMaker][Dist::Zilla::Plugin::MakeMaker] in this respect.

---
[Dist::Zilla::Plugin::MakeMaker]: https://metacpan.org/pod/Dist::Zilla::Plugin::MakeMaker

